### PR TITLE
Additional BEMIO updates

### DIFF
--- a/examples/BEMIO/CAPYTAINE/coer_comp/bemio.m
+++ b/examples/BEMIO/CAPYTAINE/coer_comp/bemio.m
@@ -1,6 +1,6 @@
 hydro = struct();
 
-hydro = readCAPYTAINE(hydro,'.\coer_comp_full.nc');
+hydro = readCAPYTAINE(hydro,'coer_comp_full.nc');
 hydro = radiationIRF(hydro,10,[],[],[],[]);
 hydro = radiationIRFSS(hydro,[],[]);
 hydro = excitationIRF(hydro,20,[],[],[],[]);

--- a/examples/BEMIO/CAPYTAINE/cubes/bemio.m
+++ b/examples/BEMIO/CAPYTAINE/cubes/bemio.m
@@ -1,6 +1,6 @@
 hydro = struct();
 
-hydro = readCAPYTAINE(hydro,'.\cubes_full.nc');
+hydro = readCAPYTAINE(hydro,'cubes_full.nc');
 hydro = radiationIRF(hydro,30,[],[],[],[]);
 hydro = radiationIRFSS(hydro,[],[]);
 hydro = excitationIRF(hydro,200,[],[],[],[]);

--- a/examples/BEMIO/CAPYTAINE/cylinder/bemio.m
+++ b/examples/BEMIO/CAPYTAINE/cylinder/bemio.m
@@ -1,6 +1,6 @@
 hydro = struct();
 
-hydro = readCAPYTAINE(hydro,'.\cylinder_full.nc');
+hydro = readCAPYTAINE(hydro,'cylinder_full.nc');
 hydro = radiationIRF(hydro,15,[],[],[],[]);
 hydro = radiationIRFSS(hydro,[],[]);
 hydro = excitationIRF(hydro,15,[],[],[],[]);

--- a/examples/BEMIO/CAPYTAINE/ellipsoid/bemio.m
+++ b/examples/BEMIO/CAPYTAINE/ellipsoid/bemio.m
@@ -1,6 +1,6 @@
 hydro = struct();
 
-hydro = readCAPYTAINE(hydro,'.\ellipsoid_full.nc');
+hydro = readCAPYTAINE(hydro,'ellipsoid_full.nc');
 hydro = radiationIRF(hydro,15,[],[],[],[]);
 hydro = radiationIRFSS(hydro,[],[]);
 hydro = excitationIRF(hydro,15,[],[],[],[]);

--- a/examples/BEMIO/CAPYTAINE/oswec/bemio.m
+++ b/examples/BEMIO/CAPYTAINE/oswec/bemio.m
@@ -1,6 +1,6 @@
 hydro = struct();
 
-hydro = readCAPYTAINE(hydro,'.\oswec_full.nc');
+hydro = readCAPYTAINE(hydro,'oswec_full.nc');
 hydro = radiationIRF(hydro,40,[],[],[],[]);
 hydro = radiationIRFSS(hydro,[],[]);
 hydro = excitationIRF(hydro,75,[],[],[],[]);

--- a/examples/BEMIO/CAPYTAINE/rm3/bemio.m
+++ b/examples/BEMIO/CAPYTAINE/rm3/bemio.m
@@ -1,6 +1,6 @@
 hydro = struct();
 
-hydro = readCAPYTAINE(hydro,'.\rm3_full.nc');
+hydro = readCAPYTAINE(hydro,'rm3_full.nc');
 hydro = radiationIRF(hydro,60,[],[],[],1.9);
 hydro = radiationIRFSS(hydro,[],[]);
 hydro = excitationIRF(hydro,157,[],[],[],1.9);

--- a/examples/BEMIO/CAPYTAINE/sphere/bemio.m
+++ b/examples/BEMIO/CAPYTAINE/sphere/bemio.m
@@ -1,6 +1,6 @@
 hydro = struct();
 
-hydro = readCAPYTAINE(hydro,'.\sphere_full.nc');
+hydro = readCAPYTAINE(hydro,'sphere_full.nc');
 hydro = radiationIRF(hydro,15,[],[],[],[]);
 hydro = radiationIRFSS(hydro,[],[]);
 hydro = excitationIRF(hydro,15,[],[],[],[]);

--- a/examples/BEMIO/NEMOH/Coer_Comp/bemio.m
+++ b/examples/BEMIO/NEMOH/Coer_Comp/bemio.m
@@ -1,7 +1,7 @@
 hydro = struct();
 
-hydro = readNEMOH(hydro,'..\Coer_Comp\');
-% hydro = readWAMIT(hydro,'..\..\WAMIT\Coer_Comp\coer_comp.out',[]);
+hydro = readNEMOH(hydro,'../Coer_Comp/');
+% hydro = readWAMIT(hydro,'../../WAMIT/Coer_Comp/coer_comp.out',[]);
 % hydro = combineBEM(hydro); % Compare to WAMIT
 hydro = radiationIRF(hydro,10,[],[],[],[]);
 hydro = radiationIRFSS(hydro,[],[]);

--- a/examples/BEMIO/NEMOH/Cubes/bemio.m
+++ b/examples/BEMIO/NEMOH/Cubes/bemio.m
@@ -1,7 +1,7 @@
 hydro = struct();
 
-hydro = readNEMOH(hydro,'..\Cubes\');
-% hydro = readWAMIT(hydro,'..\..\WAMIT\Cubes\cubes.out',[]);
+hydro = readNEMOH(hydro,'../Cubes/');
+% hydro = readWAMIT(hydro,'../../WAMIT/Cubes/cubes.out',[]);
 % hydro = combineBEM(hydro); % Compare WAMIT
 hydro = radiationIRF(hydro,20,[],[],[],[]);
 hydro = radiationIRFSS(hydro,[],[]);

--- a/examples/BEMIO/NEMOH/Cylinder/bemio.m
+++ b/examples/BEMIO/NEMOH/Cylinder/bemio.m
@@ -1,7 +1,7 @@
 hydro = struct();
 
-hydro = readNEMOH(hydro,'..\Cylinder\');
-% hydro = readWAMIT(hydro,'..\..\WAMIT\Cylinder\cyl.out',[]);
+hydro = readNEMOH(hydro,'../Cylinder/');
+% hydro = readWAMIT(hydro,'../../WAMIT/Cylinder/cyl.out',[]);
 % hydro = combineBEM(hydro);   % Compare to WAMIT
 hydro = radiationIRF(hydro,5,[],[],[],[]);
 hydro = radiationIRFSS(hydro,[],[]);

--- a/examples/BEMIO/NEMOH/Ellipsoid/bemio.m
+++ b/examples/BEMIO/NEMOH/Ellipsoid/bemio.m
@@ -1,7 +1,7 @@
 hydro = struct();
 
-hydro = readNEMOH(hydro,'..\Ellipsoid\');
-% hydro = readWAMIT(hydro,'..\..\WAMIT\Ellipsoid\ellipsoid.out',[]);
+hydro = readNEMOH(hydro,'../Ellipsoid/');
+% hydro = readWAMIT(hydro,'../../WAMIT/Ellipsoid/ellipsoid.out',[]);
 % hydro = combineBEM(hydro); % Compare to WAMIT
 hydro = radiationIRF(hydro,10,[],[],[],[]);
 hydro = radiationIRFSS(hydro,[],[]);

--- a/examples/BEMIO/NEMOH/OSWEC/bemio.m
+++ b/examples/BEMIO/NEMOH/OSWEC/bemio.m
@@ -1,7 +1,7 @@
 hydro = struct();
 
-hydro = readNEMOH(hydro,'..\OSWEC\');
-% hydro = readWAMIT(hydro,'..\..\WAMIT\OSWEC\oswec.out',[]);
+hydro = readNEMOH(hydro,'../OSWEC/');
+% hydro = readWAMIT(hydro,'../../WAMIT/OSWEC/oswec.out',[]);
 % hydro = combineBEM(hydro); % Compare WAMIT
 hydro = radiationIRF(hydro,20,[],[],[],[]);
 hydro = radiationIRFSS(hydro,[],[]);

--- a/examples/BEMIO/NEMOH/RM3/bemio.m
+++ b/examples/BEMIO/NEMOH/RM3/bemio.m
@@ -1,7 +1,7 @@
 hydro = struct();
 
-hydro = readNEMOH(hydro,'..\RM3\');
-% hydro = readWAMIT(hydro,'..\..\WAMIT\RM3\rm3.out',[]);
+hydro = readNEMOH(hydro,'../RM3/');
+% hydro = readWAMIT(hydro,'../../WAMIT/RM3/rm3.out',[]);
 % hydro = combineBEM(hydro); % Compare WAMIT
 hydro = radiationIRF(hydro,60,[],[],[],1.9);
 hydro = radiationIRFSS(hydro,[],[]);

--- a/examples/BEMIO/NEMOH/Sphere/bemio.m
+++ b/examples/BEMIO/NEMOH/Sphere/bemio.m
@@ -1,7 +1,7 @@
 hydro = struct();
 
-hydro = readNEMOH(hydro,'..\Sphere\');
-% hydro = readWAMIT(hydro,'..\..\WAMIT\Sphere\sphere.out',[]);
+hydro = readNEMOH(hydro,'../Sphere/');
+% hydro = readWAMIT(hydro,'../../WAMIT/Sphere/sphere.out',[]);
 % hydro = combineBEM(hydro); % Compare to WAMIT
 hydro = radiationIRF(hydro,15,[],[],[],[]);
 hydro = radiationIRFSS(hydro,[],[]);

--- a/source/functions/BEMIO/readAQWA.m
+++ b/source/functions/BEMIO/readAQWA.m
@@ -35,8 +35,8 @@ e = 0;
 
 hydro(F).code   = 'AQWA';
 V182            = 0; % Set AqwaVersion flag "Version 18.2 or larger" to 0
-tmp             = strsplit(ah1Filename,{' ','\', '/', '.'});
-hydro(F).file   = tmp{length(tmp)-1};  % Base filename
+[~,tmp,~]       = fileparts(ah1Filename);
+hydro(F).file   = tmp;  % Base filename
 
 fileID          = fopen(ah1Filename);
 raw1            = textscan(fileID,'%[^\n\r]'); %Read/copy raw output, ah1


### PR DESCRIPTION
Hi @ahmedmetin

In addition to your changes in #874, I'd like to update:
- the Capytaine and NEMOH examples so that the paths are OS-independent
- readAQWA to use ``fileparts`` which is more robust than manually splitting strings for a filename

Before we merge #874, can you review that these updated BEMIO examples on run on Mac and pull this into your branch?

Thanks,
Adam